### PR TITLE
Add ChatGPT builder skeleton

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,30 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.jenkins-ci.plugins</groupId>
+    <artifactId>plugin</artifactId>
+    <version>4.82</version>
+  </parent>
+  <groupId>io.jenkins.plugins</groupId>
+  <artifactId>chatgpt</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>hpi</packaging>
+  <name>ChatGPT Plugin</name>
+  <description>ChatGPT builder plugin</description>
+  <properties>
+    <jenkins.version>2.401.3</jenkins.version>
+    <java.level>11</java.level>
+  </properties>
+  <repositories>
+    <repository>
+      <id>jenkins-releases</id>
+      <url>https://repo.jenkins-ci.org/releases/</url>
+    </repository>
+  </repositories>
+  <pluginRepositories>
+    <pluginRepository>
+      <id>jenkins-releases</id>
+      <url>https://repo.jenkins-ci.org/releases/</url>
+    </pluginRepository>
+  </pluginRepositories>
+</project>

--- a/src/main/java/io/jenkins/plugins/chatgpt/ChatgptBuilder.java
+++ b/src/main/java/io/jenkins/plugins/chatgpt/ChatgptBuilder.java
@@ -1,0 +1,55 @@
+package io.jenkins.plugins.chatgpt;
+
+import hudson.Extension;
+import hudson.Launcher;
+import hudson.model.AbstractBuild;
+import hudson.model.AbstractProject;
+import hudson.model.BuildListener;
+import hudson.tasks.BuildStepDescriptor;
+import hudson.tasks.BuildStepMonitor;
+import hudson.tasks.Builder;
+import org.jenkinsci.Symbol;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+import java.io.IOException;
+
+@Symbol("chatgpt")
+@Extension
+public class ChatgptBuilder extends Builder {
+
+    private final String prompt;
+
+    @DataBoundConstructor
+    public ChatgptBuilder(String prompt) {
+        this.prompt = prompt;
+    }
+
+    public String getPrompt() {
+        return prompt;
+    }
+
+    @Override
+    public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener)
+            throws InterruptedException, IOException {
+        listener.getLogger().println("Prompt: " + prompt);
+        return true;
+    }
+
+    @Override
+    public BuildStepMonitor getRequiredMonitorService() {
+        return BuildStepMonitor.NONE;
+    }
+
+    @Extension
+    public static final class DescriptorImpl extends BuildStepDescriptor<Builder> {
+        @Override
+        public boolean isApplicable(Class<? extends AbstractProject<?, ?>> jobType) {
+            return true;
+        }
+
+        @Override
+        public String getDisplayName() {
+            return "ChatGPT Builder";
+        }
+    }
+}

--- a/src/main/resources/io/jenkins/plugins/chatgpt/ChatgptBuilder/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/chatgpt/ChatgptBuilder/config.jelly
@@ -1,0 +1,4 @@
+<?jelly escape-by-default='true'?>
+<f:entry title="Prompt" field="prompt">
+  <f:textbox />
+</f:entry>


### PR DESCRIPTION
## Summary
- scaffold Maven plugin POM using latest Jenkins plugin parent
- add `ChatgptBuilder` with prompt field and descriptor
- include Jelly config with textbox for prompt

## Testing
- `mvn -ntp -DskipTests package` *(fails: Non-resolvable parent POM: Could not transfer artifact org.jenkins-ci.plugins:plugin:pom:4.82)*

------
https://chatgpt.com/codex/tasks/task_e_6894cfd11bf483339b6badc1e9322cc5