### PR TITLE
Add .gitignore for Python and Maven artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+.venv/
+*.pyc
+target/


### PR DESCRIPTION
## Summary
- ignore Python cache and virtual env files
- ignore Maven build target directory

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_6894d16d82208333976f7402f2e3d2f8