### PR TITLE
Document FastAPI service and Jenkins plugin setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,34 @@
 # J_GPT
-Jenkins GPT
+
+J_GPT combines a FastAPI service for generating Jenkins pipelines with a simple Jenkins plugin.
+
+## FastAPI service
+The FastAPI app exposes endpoints to generate and manage Jenkinsfiles based on a project's requirements. It renders a Jenkinsfile from `templates/Jenkinsfile.j2` and supports basic tech‑stack detection.
+
+### Setup
+```bash
+pip install -r requirements.txt
+```
+
+### Run
+```bash
+uvicorn main:app --host 0.0.0.0 --port 8000 --reload
+```
+Endpoints:
+- `POST /generate` – create a Jenkinsfile from a name, tech stack and requirement description
+- `GET /list` – list previously generated pipelines
+- `GET /export/{pipeline_id}` – download a generated Jenkinsfile
+
+## Jenkins plugin
+The Jenkins plugin adds a **ChatGPT Builder** step that prints a configured prompt during a build.
+
+### Build
+```bash
+mvn package
+```
+The compiled plugin is created at `target/chatgpt.hpi`.
+
+### Configure
+1. Upload the HPI in Jenkins via **Manage Jenkins → Plugins → Advanced → Upload Plugin**.
+2. In a job, add the **ChatGPT Builder** build step and set the *Prompt* field.
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+fastapi
+uvicorn
+pydantic
+jinja2


### PR DESCRIPTION
## Summary
- Expand README with overview of the FastAPI pipeline generator and Jenkins plugin.
- Add setup instructions for Python dependencies and Maven build.
- Provide run steps for FastAPI and usage details for the ChatGPT Builder plugin.

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement fastapi)*
- `python -m py_compile main.py`
- `mvn package` *(fails: Non-resolvable parent POM for io.jenkins.plugins:chatgpt:1.0-SNAPSHOT)*

------
https://chatgpt.com/codex/tasks/task_e_6894d1e10c1083338b20801fb9b8204c