### PR TITLE
Validate Jenkinsfile syntax via external tools

### DIFF
--- a/main.py
+++ b/main.py
@@ -4,6 +4,7 @@ from typing import List, Dict, Any
 from jinja2 import Environment, FileSystemLoader
 from uuid import uuid4
 from datetime import datetime
+import subprocess
 
 app = FastAPI(title="Jenkins Pipeline Generator")
 
@@ -36,17 +37,54 @@ def detect_tech_stack(requirements: str) -> List[str]:
     return detected
 
 
-def validate_jenkinsfile(jenkinsfile: str) -> bool:
-    # Stub for syntax validation
-    return True
+def validate_jenkinsfile(jenkinsfile: str) -> tuple[bool, str]:
+    """Validate Jenkinsfile syntax using jenkins-cli or a Groovy parser.
+
+    Attempts to validate the provided Jenkinsfile by first invoking
+    ``jenkins-cli declarative-linter``. If the CLI is unavailable, it falls
+    back to calling a local ``groovy`` executable. Syntax errors from either
+    tool are captured and returned to the caller.
+
+    Returns
+    -------
+    tuple[bool, str]
+        A tuple where the boolean indicates whether the Jenkinsfile is valid
+        and the string contains any error message produced by the validator.
+    """
+
+    cmds = [
+        ("jenkins-cli", ["jenkins-cli", "declarative-linter"], True),
+        ("groovy", ["groovy", "-"], False),
+    ]
+
+    for name, cmd, use_stdin in cmds:
+        try:
+            subprocess.run(
+                cmd,
+                input=jenkinsfile if use_stdin else None,
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+            return True, ""
+        except FileNotFoundError:
+            continue  # Tool not installed; try next option
+        except subprocess.CalledProcessError as e:
+            error_msg = (e.stderr or e.stdout).strip()
+            return False, error_msg
+
+    raise HTTPException(
+        status_code=500, detail="No Jenkinsfile validator available"
+    )
 
 
 @app.post("/generate")
 def generate_pipeline(req: GenerateRequest):
     tech_stack = list({*req.tech_stack, *detect_tech_stack(req.requirements)})
     jenkinsfile = template.render(name=req.name, tech_stack=tech_stack)
-    if not validate_jenkinsfile(jenkinsfile):
-        raise HTTPException(status_code=400, detail="Invalid Jenkinsfile syntax")
+    is_valid, error_msg = validate_jenkinsfile(jenkinsfile)
+    if not is_valid:
+        raise HTTPException(status_code=400, detail=error_msg)
 
     pipeline_id = str(uuid4())
     pipelines[pipeline_id] = {


### PR DESCRIPTION
## Summary
- invoke `jenkins-cli` or a local `groovy` parser to check Jenkinsfile syntax
- return a detailed error message for invalid Jenkinsfiles

## Testing
- `python -m py_compile main.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6894d1f0d26083338abba59c098b8c9c